### PR TITLE
Update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{,**/}{actual,fixtures,expected,templates}/**/*.*]
+[{**/{actual,fixtures,expected,templates}/**,*.md}]
 trim_trailing_whitespace = false
 insert_final_newline = false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,4 @@
 {
-  "ecmaFeatures": {
-    "modules": true,
-    "experimentalObjectRestSpread": true
-  },
-
   "env": {
     "browser": false,
     "es6": true,

--- a/.gitignore
+++ b/.gitignore
@@ -6,16 +6,23 @@
 test/actual
 actual
 coverage
+.nyc*
 
 # npm
 node_modules
 npm-debug.log
 
+# yarn
+yarn.lock
+yarn-error.log
+
 # misc
 _gh_pages
-benchmark
+_draft
+_drafts
 bower_components
 vendor
 temp
 tmp
 TODO.md
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 sudo: false
+os:
+  - linux
+  - osx
 language: node_js
 node_js:
+  - node
+  - '8'
+  - '7'
+  - '6'
   - '5'
   - '4'
   - '0.12'
   - '0.10'
-matrix:
-  fast_finish: true
-  allow_failures:
-    - node_js: '4'
-    - node_js: '0.10'
-    - node_js: '0.12'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016, Jon Schlinkert.
+Copyright (c) 2016-2018, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 /*!
  * log-utils <https://github.com/jonschlinkert/log-utils>
  *
- * Copyright (c) 2016, Jon Schlinkert.
- * Licensed under the MIT License.
+ * Copyright (c) 2016-2018, Jon Schlinkert.
+ * Released under the MIT License.
  */
 
 'use strict';

--- a/index.js
+++ b/index.js
@@ -7,21 +7,32 @@
 
 'use strict';
 
-var readline = require('readline');
 var log = require('ansi-colors');
-var fn = require;
-require = log;
 
 /**
  * Utils
  */
 
-require('error-symbol');
-require('info-symbol');
-require('success-symbol', 'check');
-require('warning-symbol');
-require('time-stamp');
-require = fn;
+getter(log, 'errorSymbol', function() {
+  return require('error-symbol');
+});
+
+getter(log, 'infoSymbol', function() {
+  return require('info-symbol');
+});
+
+getter(log, 'check', function() {
+  return require('success-symbol');
+});
+
+getter(log, 'warningSymbol', function() {
+  return require('warning-symbol');
+});
+
+getter(log, 'timeStamp', function() {
+  return require('time-stamp');
+});
+
 
 /**
  * Expose `colors` and `symbols`

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "ansi-colors": "^0.2.0",
+    "ansi-colors": "^1.1.0",
     "error-symbol": "^0.1.0",
     "info-symbol": "^0.1.0",
     "log-ok": "^0.1.1",
@@ -29,9 +29,8 @@
     "warning-symbol": "^0.1.0"
   },
   "devDependencies": {
-    "clear-require": "^1.0.1",
-    "gulp-format-md": "^0.1.7",
     "mocha": "^2.4.5",
+    "clear-require": "^1.0.1",
     "verb-generate-readme": "^0.1.21"
   },
   "keywords": [
@@ -84,8 +83,5 @@
     "plugins": [
       "gulp-format-md"
     ]
-  },
-  "lintDeps": {
-    "ignore": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   },
   "license": "MIT",
   "files": [
-    "index.js",
-    "LICENSE",
-    "README.md"
+    "index.js"
   ],
   "main": "index.js",
   "engines": {

--- a/test.js
+++ b/test.js
@@ -5,10 +5,6 @@ var assert = require('assert');
 var utils = require('./');
 
 describe('log-utils', function() {
-  it('should export a (getter) function', function() {
-    assert(utils);
-    assert.equal(typeof utils, 'function');
-  });
   it('should expose getters', function() {
     assert(utils.hasOwnProperty('symbol'));
     assert(utils.hasOwnProperty('check'));


### PR DESCRIPTION
I thought this could take advantage of the changes recently made in `ansi-colors`. I had to do a little refactor because this lib was relying on the fact that `ansi-colors` used to use `lazy-cache` and exported the function. Because of this change, I think it should be a minor bump (or just go to 1.0.0).

I didn't update `time-stamp` here because the default format changed (even though one method is overriding the default, the original method is still exposed). All that said, we could still update if we do at least the minor version bump.